### PR TITLE
Remove all empty theme properties for IJ 233.* compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.gradle
+.idea
+build

--- a/resources/PreciousDarkEleven.theme.json
+++ b/resources/PreciousDarkEleven.theme.json
@@ -104,9 +104,6 @@
       "ContrastBorderColor": "border",
       "color": "border"
     },
-    "Breakpoint": {
-      "iconHoverAlpha": ""
-    },
     "Button": {
       "Split": {
         "default": {
@@ -114,7 +111,6 @@
           "separatorColor": "#48689c"
         }
       },
-      "arc": "",
       "background": "panel",
       "default": {
         "endBackground": "#4e80b2",
@@ -133,7 +129,6 @@
       "focusedBorderColor": "#496b90",
       "foreground": "foreground",
       "shadowColor": "#61616200",
-      "shadowWidth": "",
       "startBackground": "white",
       "startBorderColor": "componentBorder"
     },
@@ -147,7 +142,6 @@
       "acceleratorForeground": "foreground",
       "acceleratorSelectionForeground": "selectionForeground",
       "background": "panel",
-      "disabledBackground": "",
       "disabledForeground": "disabledForeground",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
@@ -176,43 +170,27 @@
     "ComboBoxButton": {
       "background": "contentBackground"
     },
-    "ComboPopup": {
-      "border": ""
-    },
     "CompletionPopup": {
       "Advertiser": {
         "background": "panel",
-        "borderInsets": "",
-        "fontSizeOffset": "",
         "foreground": "infoPanelForeground"
-      },
-      "Body": {
-        "insets": ""
       },
       "foreground": "foreground",
       "matchForeground": "linkForeground",
       "nonFocusedMask": "#b8b7b600",
       "selectionBackground": "#243547",
-      "selectionInactiveBackground": "grey12",
-      "selectionInnerInsets": ""
+      "selectionInactiveBackground": "grey12"
     },
     "ComplexPopup": {
       "Header": {
-        "background": "contentBackground",
-        "insets": ""
-      },
-      "TextField": {
-        "borderInsets": "",
-        "inputInsets": ""
+        "background": "contentBackground"
       }
     },
     "Component": {
-      "arc": "",
       "borderColor": "componentBorder",
       "disabledBorderColor": "border",
       "errorFocusColor": "#ab524f",
       "focusColor": "#325377",
-      "focusWidth": "",
       "focusedBorderColor": "#496b90",
       "hoverIconColor": "#727e84e5",
       "iconColor": "#727e847f",
@@ -240,21 +218,12 @@
         "valueForeground": "#d8a6a2"
       }
     },
-    "DebuggerPopup": {
-      "borderColor": ""
-    },
-    "DebuggerTabs": {
-      "underlineHeight": "",
-      "underlinedTabBackground": ""
-    },
     "DefaultTabs": {
       "background": "panel",
       "borderColor": "border",
       "hoverBackground": "#b8b7b619",
       "inactiveUnderlineColor": "#596373",
       "underlineColor": "#4e80b2",
-      "underlineHeight": "",
-      "underlinedTabBackground": "",
       "underlinedTabForeground": "foreground"
     },
     "DragAndDrop": {
@@ -265,8 +234,7 @@
     },
     "Editor": {
       "SearchField": {
-        "background": "contentBackground",
-        "borderInsets": ""
+        "background": "contentBackground"
       },
       "Toolbar": {
         "borderColor": "border"
@@ -279,7 +247,6 @@
       "background": "contentBackground",
       "caretForeground": "foreground",
       "foreground": "foreground",
-      "inactiveBackground": "",
       "inactiveForeground": "disabledForeground",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground",
@@ -291,14 +258,9 @@
       "hoverBackground": "#b8b7b619",
       "inactiveColoredFileBackground": "#b8b7b611",
       "inactiveUnderlineColor": "#596373",
-      "tabInsets": "",
       "underlineColor": "#4e80b2",
-      "underlineHeight": "",
       "underlinedTabBackground": "white",
-      "underlinedTabForeground": "foreground",
-      "unselectedAlpha": "",
-      "unselectedBlend": "",
-      "verticalTabInsets": ""
+      "underlinedTabForeground": "foreground"
     },
     "FileColor": {
       "Blue": "#242c34",
@@ -329,24 +291,14 @@
       "Header": {
         "foreground": "foreground"
       },
-      "arc": "",
       "background": "grey17",
       "borderColor": "grey05",
-      "buttonBottomInset": "",
-      "buttonTopInset": "",
-      "codeBackground": "",
       "codeBorderColor": "grey08",
-      "codeForeground": "",
       "foreground": "foreground",
-      "iconInset": "",
-      "imageBottomInset": "",
-      "imageTopInset": "",
-      "insets": "",
       "linkForeground": "linkForeground",
       "shortcutBackground": "#252d34",
       "shortcutForeground": "foreground",
-      "stepForeground": "foreground",
-      "textInset": ""
+      "stepForeground": "foreground"
     },
     "Group": {
       "disabledSeparatorColor": "border",
@@ -356,14 +308,7 @@
       "infoForeground": "infoPanelForeground",
       "lineSeparatorColor": "grey12"
     },
-    "HelpTooltip": {
-      "borderColor": ""
-    },
     "IconBadge": {
-      "borderWidth": "",
-      "dotRadius": "",
-      "dotX": "",
-      "dotY": "",
       "errorBackground": "#c65a56",
       "infoBackground": "#3e81b9",
       "successBackground": "#5b8b3d",
@@ -371,9 +316,6 @@
     },
     "InformationHint": {
       "borderColor": "#2f3132"
-    },
-    "InplaceRefactoringPopup": {
-      "borderColor": ""
     },
     "Label": {
       "background": "panel",
@@ -403,9 +345,7 @@
     "List": {
       "Button": {
         "hoverBackground": "#20272f",
-        "leftRightInset": "",
-        "separatorColor": "contentBackground",
-        "separatorInset": ""
+        "separatorColor": "contentBackground"
       },
       "Line": {
         "hoverBackground": "grey12"
@@ -428,11 +368,7 @@
       "transparentSelectionBackground": "selectionBackground"
     },
     "MainToolbar": {
-      "Dropdown": {
-        "maxWidth": ""
-      },
-      "background": "panel",
-      "separatorColor": ""
+      "background": "panel"
     },
     "MainWindow": {
       "FullScreeControl": {
@@ -455,17 +391,10 @@
       "usedBackground": "grey06"
     },
     "Menu": {
-      "Selection": {
-        "arc": "",
-        "innerInsets": "",
-        "outerInsets": ""
-      },
       "acceleratorForeground": "foreground",
       "acceleratorSelectionForeground": "selectionForeground",
       "background": "panel",
       "borderColor": "lightBorder",
-      "borderInsets": "",
-      "disabledBackground": "",
       "disabledForeground": "disabledForeground",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
@@ -475,17 +404,13 @@
     "MenuBar": {
       "borderColor": "lightBorder",
       "disabledBackground": "border",
-      "disabledForeground": "",
       "foreground": "foreground",
       "highlight": "white",
-      "selectionBackground": "",
-      "selectionForeground": "",
       "shadow": "#364359"
     },
     "MenuItem": {
       "acceleratorForeground": "infoPanelForeground",
       "background": "panel",
-      "disabledBackground": "",
       "disabledForeground": "disabledForeground",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
@@ -516,37 +441,18 @@
         "warningBorderColor": "#746033",
         "warningForeground": "foreground"
       },
-      "arc": "",
       "background": "panel",
       "borderColor": "border",
-      "borderInsets": "",
-      "contentActionsInset": "",
       "errorBackground": "#302629",
       "errorBorderColor": "#774745",
       "errorForeground": "foreground",
-      "foreground": "foreground",
-      "iconOffsetSize": "",
-      "linkForeground": "",
-      "titleActionsInset": "",
-      "titleContentInset": ""
+      "foreground": "foreground"
     },
     "NotificationsToolwindow": {
-      "Notification": {
-        "hoverBackground": ""
-      },
       "newNotification": {
         "background": "#252d34",
         "hoverBackground": "#252d34"
       }
-    },
-    "OnePixelDivider": {
-      "background": ""
-    },
-    "OptionButton": {
-      "default": {
-        "separatorColor": ""
-      },
-      "separatorColor": ""
     },
     "OptionPane": {
       "background": "panel",
@@ -570,7 +476,6 @@
     },
     "PasswordField": {
       "background": "contentBackground",
-      "capsLockIconColor": "",
       "caretForeground": "foreground",
       "foreground": "foreground",
       "inactiveForeground": "disabledForeground",
@@ -601,11 +506,6 @@
         "background": "grey17",
         "foreground": "infoPanelForeground"
       },
-      "Tab": {
-        "hoverBackground": "",
-        "selectedBackground": "",
-        "selectedForeground": ""
-      },
       "background": "contentBackground",
       "borderColor": "border",
       "disabledForeground": "disabledForeground",
@@ -620,29 +520,13 @@
       "Advertiser": {
         "background": "panel",
         "borderColor": "border",
-        "borderInsets": "",
         "foreground": "infoPanelForeground"
-      },
-      "Body": {
-        "bottomInsetBeforeAd": "",
-        "bottomInsetNoAd": "",
-        "topInsetNoHeader": ""
       },
       "Header": {
         "activeBackground": "grey13",
         "activeForeground": "foreground",
         "inactiveBackground": "grey14",
-        "inactiveForeground": "disabledForeground",
-        "insets": ""
-      },
-      "SearchField": {
-        "borderInsets": "",
-        "inputInsets": ""
-      },
-      "Selection": {
-        "arc": "",
-        "innerInsets": "",
-        "leftRightInset": ""
+        "inactiveForeground": "disabledForeground"
       },
       "Toolbar": {
         "background": "grey17",
@@ -650,36 +534,17 @@
       },
       "background": "contentBackground",
       "borderColor": "grey05",
-      "borderWidth": "",
       "inactiveBorderColor": "grey05",
-      "innerBorderColor": "",
-      "paintBorder": "",
       "separatorColor": "lightBorder",
-      "separatorForeground": "separatorForeground",
-      "separatorInsets": "",
-      "separatorLabelInsets": ""
+      "separatorForeground": "separatorForeground"
     },
     "PopupMenu": {
-      "Selection": {
-        "arc": "",
-        "innerInsets": "",
-        "outerInsets": ""
-      },
       "background": "panel",
       "borderInsets": "6,1,6,1",
-      "borderWidth": "",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground",
       "translucentBackground": "panel"
-    },
-    "PopupMenuSeparator": {
-      "height": "",
-      "stripeIndent": "",
-      "stripeWidth": ""
-    },
-    "ProblemsView": {
-      "projectAnalysisButtonBackground": ""
     },
     "ProgressBar": {
       "background": "panel",
@@ -709,7 +574,6 @@
       "acceleratorForeground": "foreground",
       "acceleratorSelectionForeground": "selectionForeground",
       "background": "panel",
-      "disabledBackground": "",
       "disabledForeground": "disabledForeground",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
@@ -718,9 +582,6 @@
     "RunToolbar": {
       "Debug": {
         "activeBackground": "#2b2923"
-      },
-      "Profile": {
-        "activeBackground": ""
       },
       "Run": {
         "activeBackground": "#232b24"
@@ -782,7 +643,6 @@
     "SearchEverywhere": {
       "Advertiser": {
         "background": "panel",
-        "borderInsets": "",
         "foreground": "infoPanelForeground"
       },
       "Header": {
@@ -830,9 +690,6 @@
         "borderColor": "#9bb55364"
       }
     },
-    "SettingsTree": {
-      "rowHeight": ""
-    },
     "SidePanel": {
       "background": "#23292e"
     },
@@ -877,8 +734,6 @@
       "focusColor": "#252f36",
       "foreground": "foreground",
       "hoverColor": "grey11",
-      "tabSelectionArc": "",
-      "tabSelectionHeight": "",
       "underlineColor": "#4e80b2"
     },
     "Table": {
@@ -898,8 +753,6 @@
       "lightSelectionInactiveForeground": "foreground",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground",
-      "selectionInactiveBackground": "",
-      "selectionInactiveForeground": "",
       "sortIconColor": "#364359",
       "stripeColor": "#1e2227"
     },
@@ -923,9 +776,6 @@
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground"
     },
-    "TextComponent": {
-      "selectionBackgroundInactive": ""
-    },
     "TextField": {
       "background": "contentBackground",
       "caretForeground": "foreground",
@@ -940,7 +790,6 @@
       "background": "panel",
       "caretForeground": "foreground",
       "foreground": "foreground",
-      "inactiveBackground": "",
       "inactiveForeground": "disabledForeground",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground"
@@ -975,16 +824,13 @@
     },
     "ToolBar": {
       "background": "panel",
-      "borderHandleColor": "",
       "darkShadow": "#6f7e8c",
       "floatingForeground": "#364359",
       "foreground": "foreground",
       "highlight": "white",
-      "horizontalToolbarInsets": "",
       "light": "white",
       "separatorColor": "border",
-      "shadow": "#364359",
-      "verticalToolbarInsets": ""
+      "shadow": "#364359"
     },
     "ToolTip": {
       "Actions": {
@@ -996,7 +842,6 @@
       "foreground": "foreground",
       "infoForeground": "infoPanelForeground",
       "linkForeground": "linkForeground",
-      "paintBorder": "",
       "shortcutForeground": "infoPanelForeground"
     },
     "ToolWindow": {
@@ -1009,7 +854,6 @@
         "background": "#282d33",
         "borderColor": "border",
         "inactiveBackground": "panel",
-        "padding": ""
       },
       "HeaderCloseButton": {
         "background": "grey07"
@@ -1018,19 +862,14 @@
         "hoverBackground": "#b8b7b619",
         "hoverInactiveBackground": "#b8b7b619",
         "inactiveUnderlineColor": "#596373",
-        "padding": "",
         "selectedInactiveBackground": "grey11",
-        "underlineColor": "#4e80b2",
-        "underlineHeight": "",
-        "underlinedTabBackground": "",
-        "underlinedTabInactiveBackground": ""
+        "underlineColor": "#4e80b2"
       },
       "background": "contentBackground"
     },
     "Toolbar": {
       "Floating": {
-        "background": "grey14",
-        "borderColor": ""
+        "background": "grey14"
       }
     },
     "Tooltip": {
@@ -1046,9 +885,6 @@
       "separatorColor": "border"
     },
     "Tree": {
-      "Selection": {
-        "arc": ""
-      },
       "background": "contentBackground",
       "errorForeground": "#ff8882",
       "forceFocusedSelectionForeground": false,
@@ -1057,19 +893,9 @@
       "hoverBackground": "#20272f",
       "hoverInactiveBackground": "grey16",
       "modifiedItemForeground": "#68b0ee",
-      "paintLines": "",
-      "rowHeight": "",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground",
       "selectionInactiveBackground": "grey11"
-    },
-    "UiDesigner": {
-      "Panel": {
-        "background": ""
-      },
-      "Preview": {
-        "background": ""
-      }
     },
     "ValidationTooltip": {
       "errorBackground": "#312727",
@@ -1107,7 +933,6 @@
           },
           "currentBranchBackground": "#20262e",
           "hoveredBackground": "#303d4c66",
-          "rowHeight": "",
           "selectionBackground": "selectionBackground",
           "selectionForeground": "selectionForeground",
           "selectionInactiveBackground": "grey11",
@@ -1119,12 +944,10 @@
         "Toolbar": {
           "background": "panel"
         },
-        "borderColor": "#3d3f40",
-        "borderInsets": ""
+        "borderColor": "#3d3f40"
       },
       "RefLabel": {
         "backgroundBase": "black",
-        "backgroundBrightness": "",
         "foreground": "foreground"
       }
     },
@@ -1136,20 +959,12 @@
       "Details": {
         "background": "white"
       },
-      "LearnTab": {
-        "CourseCard": {
-          "hover": ""
-        }
-      },
       "Projects": {
         "actions": {
           "background": "#222e3a",
           "selectionBackground": "#5a84c9",
           "selectionBorderColor": "#6896e1"
-        },
-        "background": "",
-        "selectionBackground": "",
-        "selectionInactiveBackground": ""
+        }
       },
       "SidePanel": {
         "background": "panel"
@@ -1164,9 +979,6 @@
       "headerBackground": "#323435",
       "headerForeground": "grey02",
       "separatorColor": "border"
-    },
-    "Window": {
-      "border": ""
     },
     "textText": "foreground",
     "window": "panel",

--- a/resources/PreciousDarkFifteen.theme.json
+++ b/resources/PreciousDarkFifteen.theme.json
@@ -104,9 +104,6 @@
       "ContrastBorderColor": "border",
       "color": "border"
     },
-    "Breakpoint": {
-      "iconHoverAlpha": ""
-    },
     "Button": {
       "Split": {
         "default": {
@@ -114,7 +111,6 @@
           "separatorColor": "#4b6ca2"
         }
       },
-      "arc": "",
       "background": "panel",
       "default": {
         "endBackground": "#5083b6",
@@ -133,7 +129,6 @@
       "focusedBorderColor": "#4c6f96",
       "foreground": "foreground",
       "shadowColor": "#66676900",
-      "shadowWidth": "",
       "startBackground": "white",
       "startBorderColor": "componentBorder"
     },
@@ -147,7 +142,6 @@
       "acceleratorForeground": "foreground",
       "acceleratorSelectionForeground": "selectionForeground",
       "background": "panel",
-      "disabledBackground": "",
       "disabledForeground": "disabledForeground",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
@@ -176,43 +170,27 @@
     "ComboBoxButton": {
       "background": "contentBackground"
     },
-    "ComboPopup": {
-      "border": ""
-    },
     "CompletionPopup": {
       "Advertiser": {
         "background": "panel",
-        "borderInsets": "",
-        "fontSizeOffset": "",
         "foreground": "infoPanelForeground"
-      },
-      "Body": {
-        "insets": ""
       },
       "foreground": "foreground",
       "matchForeground": "linkForeground",
       "nonFocusedMask": "#bab9b600",
       "selectionBackground": "#2a3c50",
-      "selectionInactiveBackground": "grey12",
-      "selectionInnerInsets": ""
+      "selectionInactiveBackground": "grey12"
     },
     "ComplexPopup": {
       "Header": {
-        "background": "contentBackground",
-        "insets": ""
-      },
-      "TextField": {
-        "borderInsets": "",
-        "inputInsets": ""
+        "background": "contentBackground"
       }
     },
     "Component": {
-      "arc": "",
       "borderColor": "componentBorder",
       "disabledBorderColor": "border",
       "errorFocusColor": "#af5653",
       "focusColor": "#36597e",
-      "focusWidth": "",
       "focusedBorderColor": "#4c6f96",
       "hoverIconColor": "#768289e5",
       "iconColor": "#7682897f",
@@ -240,21 +218,12 @@
         "valueForeground": "#d9a8a2"
       }
     },
-    "DebuggerPopup": {
-      "borderColor": ""
-    },
-    "DebuggerTabs": {
-      "underlineHeight": "",
-      "underlinedTabBackground": ""
-    },
     "DefaultTabs": {
       "background": "panel",
       "borderColor": "border",
       "hoverBackground": "#bab9b619",
       "inactiveUnderlineColor": "#5d6879",
       "underlineColor": "#5083b6",
-      "underlineHeight": "",
-      "underlinedTabBackground": "",
       "underlinedTabForeground": "foreground"
     },
     "DragAndDrop": {
@@ -265,8 +234,7 @@
     },
     "Editor": {
       "SearchField": {
-        "background": "contentBackground",
-        "borderInsets": ""
+        "background": "contentBackground"
       },
       "Toolbar": {
         "borderColor": "border"
@@ -279,7 +247,6 @@
       "background": "contentBackground",
       "caretForeground": "foreground",
       "foreground": "foreground",
-      "inactiveBackground": "",
       "inactiveForeground": "disabledForeground",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground",
@@ -291,14 +258,9 @@
       "hoverBackground": "#bab9b619",
       "inactiveColoredFileBackground": "#bab9b611",
       "inactiveUnderlineColor": "#5d6879",
-      "tabInsets": "",
       "underlineColor": "#5083b6",
-      "underlineHeight": "",
       "underlinedTabBackground": "white",
-      "underlinedTabForeground": "foreground",
-      "unselectedAlpha": "",
-      "unselectedBlend": "",
-      "verticalTabInsets": ""
+      "underlinedTabForeground": "foreground"
     },
     "FileColor": {
       "Blue": "#2a333e",
@@ -329,24 +291,14 @@
       "Header": {
         "foreground": "foreground"
       },
-      "arc": "",
       "background": "grey17",
       "borderColor": "grey05",
-      "buttonBottomInset": "",
-      "buttonTopInset": "",
-      "codeBackground": "",
       "codeBorderColor": "grey08",
-      "codeForeground": "",
       "foreground": "foreground",
-      "iconInset": "",
-      "imageBottomInset": "",
-      "imageTopInset": "",
-      "insets": "",
       "linkForeground": "linkForeground",
       "shortcutBackground": "#2b343e",
       "shortcutForeground": "foreground",
-      "stepForeground": "foreground",
-      "textInset": ""
+      "stepForeground": "foreground"
     },
     "Group": {
       "disabledSeparatorColor": "border",
@@ -356,14 +308,7 @@
       "infoForeground": "infoPanelForeground",
       "lineSeparatorColor": "grey12"
     },
-    "HelpTooltip": {
-      "borderColor": ""
-    },
     "IconBadge": {
-      "borderWidth": "",
-      "dotRadius": "",
-      "dotX": "",
-      "dotY": "",
       "errorBackground": "#c95d59",
       "infoBackground": "#3f84bd",
       "successBackground": "#5e8e41",
@@ -371,9 +316,6 @@
     },
     "InformationHint": {
       "borderColor": "#36383c"
-    },
-    "InplaceRefactoringPopup": {
-      "borderColor": ""
     },
     "Label": {
       "background": "panel",
@@ -403,9 +345,7 @@
     "List": {
       "Button": {
         "hoverBackground": "#272f39",
-        "leftRightInset": "",
-        "separatorColor": "contentBackground",
-        "separatorInset": ""
+        "separatorColor": "contentBackground"
       },
       "Line": {
         "hoverBackground": "grey12"
@@ -428,11 +368,7 @@
       "transparentSelectionBackground": "selectionBackground"
     },
     "MainToolbar": {
-      "Dropdown": {
-        "maxWidth": ""
-      },
-      "background": "panel",
-      "separatorColor": ""
+      "background": "panel"
     },
     "MainWindow": {
       "FullScreeControl": {
@@ -455,17 +391,10 @@
       "usedBackground": "grey06"
     },
     "Menu": {
-      "Selection": {
-        "arc": "",
-        "innerInsets": "",
-        "outerInsets": ""
-      },
       "acceleratorForeground": "foreground",
       "acceleratorSelectionForeground": "selectionForeground",
       "background": "panel",
       "borderColor": "lightBorder",
-      "borderInsets": "",
-      "disabledBackground": "",
       "disabledForeground": "disabledForeground",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
@@ -475,17 +404,13 @@
     "MenuBar": {
       "borderColor": "lightBorder",
       "disabledBackground": "border",
-      "disabledForeground": "",
       "foreground": "foreground",
       "highlight": "white",
-      "selectionBackground": "",
-      "selectionForeground": "",
       "shadow": "#3b4961"
     },
     "MenuItem": {
       "acceleratorForeground": "infoPanelForeground",
       "background": "panel",
-      "disabledBackground": "",
       "disabledForeground": "disabledForeground",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
@@ -516,37 +441,18 @@
         "warningBorderColor": "#786539",
         "warningForeground": "foreground"
       },
-      "arc": "",
       "background": "panel",
       "borderColor": "border",
-      "borderInsets": "",
-      "contentActionsInset": "",
       "errorBackground": "#372e33",
       "errorBorderColor": "#7c4d4b",
       "errorForeground": "foreground",
-      "foreground": "foreground",
-      "iconOffsetSize": "",
-      "linkForeground": "",
-      "titleActionsInset": "",
-      "titleContentInset": ""
+      "foreground": "foreground"
     },
     "NotificationsToolwindow": {
-      "Notification": {
-        "hoverBackground": ""
-      },
       "newNotification": {
         "background": "#2b343e",
         "hoverBackground": "#2b343e"
       }
-    },
-    "OnePixelDivider": {
-      "background": ""
-    },
-    "OptionButton": {
-      "default": {
-        "separatorColor": ""
-      },
-      "separatorColor": ""
     },
     "OptionPane": {
       "background": "panel",
@@ -570,7 +476,6 @@
     },
     "PasswordField": {
       "background": "contentBackground",
-      "capsLockIconColor": "",
       "caretForeground": "foreground",
       "foreground": "foreground",
       "inactiveForeground": "disabledForeground",
@@ -601,11 +506,6 @@
         "background": "grey17",
         "foreground": "infoPanelForeground"
       },
-      "Tab": {
-        "hoverBackground": "",
-        "selectedBackground": "",
-        "selectedForeground": ""
-      },
       "background": "contentBackground",
       "borderColor": "border",
       "disabledForeground": "disabledForeground",
@@ -620,29 +520,13 @@
       "Advertiser": {
         "background": "panel",
         "borderColor": "border",
-        "borderInsets": "",
         "foreground": "infoPanelForeground"
-      },
-      "Body": {
-        "bottomInsetBeforeAd": "",
-        "bottomInsetNoAd": "",
-        "topInsetNoHeader": ""
       },
       "Header": {
         "activeBackground": "grey13",
         "activeForeground": "foreground",
         "inactiveBackground": "grey14",
-        "inactiveForeground": "disabledForeground",
-        "insets": ""
-      },
-      "SearchField": {
-        "borderInsets": "",
-        "inputInsets": ""
-      },
-      "Selection": {
-        "arc": "",
-        "innerInsets": "",
-        "leftRightInset": ""
+        "inactiveForeground": "disabledForeground"
       },
       "Toolbar": {
         "background": "grey17",
@@ -650,36 +534,17 @@
       },
       "background": "contentBackground",
       "borderColor": "grey05",
-      "borderWidth": "",
       "inactiveBorderColor": "grey05",
-      "innerBorderColor": "",
-      "paintBorder": "",
       "separatorColor": "lightBorder",
-      "separatorForeground": "separatorForeground",
-      "separatorInsets": "",
-      "separatorLabelInsets": ""
+      "separatorForeground": "separatorForeground"
     },
     "PopupMenu": {
-      "Selection": {
-        "arc": "",
-        "innerInsets": "",
-        "outerInsets": ""
-      },
       "background": "panel",
       "borderInsets": "6,1,6,1",
-      "borderWidth": "",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground",
       "translucentBackground": "panel"
-    },
-    "PopupMenuSeparator": {
-      "height": "",
-      "stripeIndent": "",
-      "stripeWidth": ""
-    },
-    "ProblemsView": {
-      "projectAnalysisButtonBackground": ""
     },
     "ProgressBar": {
       "background": "panel",
@@ -709,7 +574,6 @@
       "acceleratorForeground": "foreground",
       "acceleratorSelectionForeground": "selectionForeground",
       "background": "panel",
-      "disabledBackground": "",
       "disabledForeground": "disabledForeground",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
@@ -718,9 +582,6 @@
     "RunToolbar": {
       "Debug": {
         "activeBackground": "#32312d"
-      },
-      "Profile": {
-        "activeBackground": ""
       },
       "Run": {
         "activeBackground": "#2a332e"
@@ -782,7 +643,6 @@
     "SearchEverywhere": {
       "Advertiser": {
         "background": "panel",
-        "borderInsets": "",
         "foreground": "infoPanelForeground"
       },
       "Header": {
@@ -830,9 +690,6 @@
         "borderColor": "#9bb55564"
       }
     },
-    "SettingsTree": {
-      "rowHeight": ""
-    },
     "SidePanel": {
       "background": "#2a3138"
     },
@@ -877,8 +734,6 @@
       "focusColor": "#2b3640",
       "foreground": "foreground",
       "hoverColor": "grey11",
-      "tabSelectionArc": "",
-      "tabSelectionHeight": "",
       "underlineColor": "#5083b6"
     },
     "Table": {
@@ -898,8 +753,6 @@
       "lightSelectionInactiveForeground": "foreground",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground",
-      "selectionInactiveBackground": "",
-      "selectionInactiveForeground": "",
       "sortIconColor": "#3b4961",
       "stripeColor": "#252a31"
     },
@@ -923,9 +776,6 @@
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground"
     },
-    "TextComponent": {
-      "selectionBackgroundInactive": ""
-    },
     "TextField": {
       "background": "contentBackground",
       "caretForeground": "foreground",
@@ -940,7 +790,6 @@
       "background": "panel",
       "caretForeground": "foreground",
       "foreground": "foreground",
-      "inactiveBackground": "",
       "inactiveForeground": "disabledForeground",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground"
@@ -975,16 +824,13 @@
     },
     "ToolBar": {
       "background": "panel",
-      "borderHandleColor": "",
       "darkShadow": "#728291",
       "floatingForeground": "#3b4961",
       "foreground": "foreground",
       "highlight": "white",
-      "horizontalToolbarInsets": "",
       "light": "white",
       "separatorColor": "border",
-      "shadow": "#3b4961",
-      "verticalToolbarInsets": ""
+      "shadow": "#3b4961"
     },
     "ToolTip": {
       "Actions": {
@@ -996,7 +842,6 @@
       "foreground": "foreground",
       "infoForeground": "infoPanelForeground",
       "linkForeground": "linkForeground",
-      "paintBorder": "",
       "shortcutForeground": "infoPanelForeground"
     },
     "ToolWindow": {
@@ -1008,8 +853,7 @@
       "Header": {
         "background": "#2e343d",
         "borderColor": "border",
-        "inactiveBackground": "panel",
-        "padding": ""
+        "inactiveBackground": "panel"
       },
       "HeaderCloseButton": {
         "background": "grey07"
@@ -1018,19 +862,14 @@
         "hoverBackground": "#bab9b619",
         "hoverInactiveBackground": "#bab9b619",
         "inactiveUnderlineColor": "#5d6879",
-        "padding": "",
         "selectedInactiveBackground": "grey11",
-        "underlineColor": "#5083b6",
-        "underlineHeight": "",
-        "underlinedTabBackground": "",
-        "underlinedTabInactiveBackground": ""
+        "underlineColor": "#5083b6"
       },
       "background": "contentBackground"
     },
     "Toolbar": {
       "Floating": {
-        "background": "grey14",
-        "borderColor": ""
+        "background": "grey14"
       }
     },
     "Tooltip": {
@@ -1046,9 +885,6 @@
       "separatorColor": "border"
     },
     "Tree": {
-      "Selection": {
-        "arc": ""
-      },
       "background": "contentBackground",
       "errorForeground": "#ff8882",
       "forceFocusedSelectionForeground": false,
@@ -1057,19 +893,9 @@
       "hoverBackground": "#272f39",
       "hoverInactiveBackground": "grey16",
       "modifiedItemForeground": "#66b0ef",
-      "paintLines": "",
-      "rowHeight": "",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground",
       "selectionInactiveBackground": "grey11"
-    },
-    "UiDesigner": {
-      "Panel": {
-        "background": ""
-      },
-      "Preview": {
-        "background": ""
-      }
     },
     "ValidationTooltip": {
       "errorBackground": "#382f31",
@@ -1107,7 +933,6 @@
           },
           "currentBranchBackground": "#272e38",
           "hoveredBackground": "#36445566",
-          "rowHeight": "",
           "selectionBackground": "selectionBackground",
           "selectionForeground": "selectionForeground",
           "selectionInactiveBackground": "grey11",
@@ -1119,12 +944,10 @@
         "Toolbar": {
           "background": "panel"
         },
-        "borderColor": "#444649",
-        "borderInsets": ""
+        "borderColor": "#444649"
       },
       "RefLabel": {
         "backgroundBase": "black",
-        "backgroundBrightness": "",
         "foreground": "foreground"
       }
     },
@@ -1136,20 +959,12 @@
       "Details": {
         "background": "white"
       },
-      "LearnTab": {
-        "CourseCard": {
-          "hover": ""
-        }
-      },
       "Projects": {
         "actions": {
           "background": "#283544",
           "selectionBackground": "#5b86cd",
           "selectionBorderColor": "#6897e4"
-        },
-        "background": "",
-        "selectionBackground": "",
-        "selectionInactiveBackground": ""
+        }
       },
       "SidePanel": {
         "background": "panel"
@@ -1164,9 +979,6 @@
       "headerBackground": "#393b3f",
       "headerForeground": "grey02",
       "separatorColor": "border"
-    },
-    "Window": {
-      "border": ""
     },
     "textText": "foreground",
     "window": "panel",

--- a/resources/PreciousLightWarm.theme.json
+++ b/resources/PreciousLightWarm.theme.json
@@ -104,9 +104,6 @@
       "ContrastBorderColor": "border",
       "color": "border"
     },
-    "Breakpoint": {
-      "iconHoverAlpha": ""
-    },
     "Button": {
       "Split": {
         "default": {
@@ -114,7 +111,6 @@
           "separatorColor": "#85a8df"
         }
       },
-      "arc": "",
       "background": "panel",
       "default": {
         "endBackground": "#6595c6",
@@ -133,7 +129,6 @@
       "focusedBorderColor": "#87a8cd",
       "foreground": "foreground",
       "shadowColor": "#a6a4a000",
-      "shadowWidth": "",
       "startBackground": "white",
       "startBorderColor": "componentBorder"
     },
@@ -147,7 +142,6 @@
       "acceleratorForeground": "foreground",
       "acceleratorSelectionForeground": "selectionForeground",
       "background": "panel",
-      "disabledBackground": "",
       "disabledForeground": "disabledForeground",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
@@ -176,43 +170,27 @@
     "ComboBoxButton": {
       "background": "contentBackground"
     },
-    "ComboPopup": {
-      "border": ""
-    },
     "CompletionPopup": {
       "Advertiser": {
         "background": "panel",
-        "borderInsets": "",
-        "fontSizeOffset": "",
         "foreground": "infoPanelForeground"
-      },
-      "Body": {
-        "insets": ""
       },
       "foreground": "foreground",
       "matchForeground": "linkForeground",
       "nonFocusedMask": "#4e535900",
       "selectionBackground": "#d2dfeb",
-      "selectionInactiveBackground": "grey12",
-      "selectionInnerInsets": ""
+      "selectionInactiveBackground": "grey12"
     },
     "ComplexPopup": {
       "Header": {
-        "background": "contentBackground",
-        "insets": ""
-      },
-      "TextField": {
-        "borderInsets": "",
-        "inputInsets": ""
+        "background": "contentBackground"
       }
     },
     "Component": {
-      "arc": "",
       "borderColor": "componentBorder",
       "disabledBorderColor": "border",
       "errorFocusColor": "#e0857f",
       "focusColor": "#9dc0e3",
-      "focusWidth": "",
       "focusedBorderColor": "#87a8cd",
       "hoverIconColor": "#828d91e5",
       "iconColor": "#828d917f",
@@ -240,21 +218,12 @@
         "valueForeground": "#785151"
       }
     },
-    "DebuggerPopup": {
-      "borderColor": ""
-    },
-    "DebuggerTabs": {
-      "underlineHeight": "",
-      "underlinedTabBackground": ""
-    },
     "DefaultTabs": {
       "background": "panel",
       "borderColor": "border",
       "hoverBackground": "#4e535919",
       "inactiveUnderlineColor": "#a1aab7",
       "underlineColor": "#6595c6",
-      "underlineHeight": "",
-      "underlinedTabBackground": "",
       "underlinedTabForeground": "foreground"
     },
     "DragAndDrop": {
@@ -265,8 +234,7 @@
     },
     "Editor": {
       "SearchField": {
-        "background": "contentBackground",
-        "borderInsets": ""
+        "background": "contentBackground"
       },
       "Toolbar": {
         "borderColor": "border"
@@ -279,7 +247,6 @@
       "background": "contentBackground",
       "caretForeground": "foreground",
       "foreground": "foreground",
-      "inactiveBackground": "",
       "inactiveForeground": "disabledForeground",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground",
@@ -291,14 +258,9 @@
       "hoverBackground": "#4e535919",
       "inactiveColoredFileBackground": "#4e535911",
       "inactiveUnderlineColor": "#a1aab7",
-      "tabInsets": "",
       "underlineColor": "#6595c6",
-      "underlineHeight": "",
       "underlinedTabBackground": "white",
-      "underlinedTabForeground": "foreground",
-      "unselectedAlpha": "",
-      "unselectedBlend": "",
-      "verticalTabInsets": ""
+      "underlinedTabForeground": "foreground"
     },
     "FileColor": {
       "Blue": "#e7e7e4",
@@ -329,24 +291,14 @@
       "Header": {
         "foreground": "foreground"
       },
-      "arc": "",
       "background": "grey17",
       "borderColor": "grey05",
-      "buttonBottomInset": "",
-      "buttonTopInset": "",
-      "codeBackground": "",
       "codeBorderColor": "grey08",
-      "codeForeground": "",
       "foreground": "foreground",
-      "iconInset": "",
-      "imageBottomInset": "",
-      "imageTopInset": "",
-      "insets": "",
       "linkForeground": "linkForeground",
       "shortcutBackground": "#e7e6e2",
       "shortcutForeground": "foreground",
-      "stepForeground": "foreground",
-      "textInset": ""
+      "stepForeground": "foreground"
     },
     "Group": {
       "disabledSeparatorColor": "border",
@@ -356,14 +308,7 @@
       "infoForeground": "infoPanelForeground",
       "lineSeparatorColor": "grey12"
     },
-    "HelpTooltip": {
-      "borderColor": ""
-    },
     "IconBadge": {
-      "borderWidth": "",
-      "dotRadius": "",
-      "dotX": "",
-      "dotY": "",
       "errorBackground": "#db706b",
       "infoBackground": "#5796cc",
       "successBackground": "#709f56",
@@ -371,9 +316,6 @@
     },
     "InformationHint": {
       "borderColor": "#e4dcd0"
-    },
-    "InplaceRefactoringPopup": {
-      "borderColor": ""
     },
     "Label": {
       "background": "panel",
@@ -403,9 +345,7 @@
     "List": {
       "Button": {
         "hoverBackground": "#eeece6",
-        "leftRightInset": "",
-        "separatorColor": "contentBackground",
-        "separatorInset": ""
+        "separatorColor": "contentBackground"
       },
       "Line": {
         "hoverBackground": "grey12"
@@ -428,11 +368,7 @@
       "transparentSelectionBackground": "selectionBackground"
     },
     "MainToolbar": {
-      "Dropdown": {
-        "maxWidth": ""
-      },
-      "background": "panel",
-      "separatorColor": ""
+      "background": "panel"
     },
     "MainWindow": {
       "FullScreeControl": {
@@ -455,17 +391,10 @@
       "usedBackground": "grey06"
     },
     "Menu": {
-      "Selection": {
-        "arc": "",
-        "innerInsets": "",
-        "outerInsets": ""
-      },
       "acceleratorForeground": "foreground",
       "acceleratorSelectionForeground": "selectionForeground",
       "background": "panel",
       "borderColor": "lightBorder",
-      "borderInsets": "",
-      "disabledBackground": "",
       "disabledForeground": "disabledForeground",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
@@ -475,17 +404,13 @@
     "MenuBar": {
       "borderColor": "lightBorder",
       "disabledBackground": "border",
-      "disabledForeground": "",
       "foreground": "foreground",
       "highlight": "white",
-      "selectionBackground": "",
-      "selectionForeground": "",
       "shadow": "#c3cee0"
     },
     "MenuItem": {
       "acceleratorForeground": "infoPanelForeground",
       "background": "panel",
-      "disabledBackground": "",
       "disabledForeground": "disabledForeground",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
@@ -516,37 +441,18 @@
         "warningBorderColor": "#bda97d",
         "warningForeground": "foreground"
       },
-      "arc": "",
       "background": "panel",
       "borderColor": "border",
-      "borderInsets": "",
-      "contentActionsInset": "",
       "errorBackground": "#fae4d8",
       "errorBorderColor": "#e3aba3",
       "errorForeground": "foreground",
-      "foreground": "foreground",
-      "iconOffsetSize": "",
-      "linkForeground": "",
-      "titleActionsInset": "",
-      "titleContentInset": ""
+      "foreground": "foreground"
     },
     "NotificationsToolwindow": {
-      "Notification": {
-        "hoverBackground": ""
-      },
       "newNotification": {
         "background": "#e7e6e2",
         "hoverBackground": "#e7e6e2"
       }
-    },
-    "OnePixelDivider": {
-      "background": ""
-    },
-    "OptionButton": {
-      "default": {
-        "separatorColor": ""
-      },
-      "separatorColor": ""
     },
     "OptionPane": {
       "background": "panel",
@@ -570,7 +476,6 @@
     },
     "PasswordField": {
       "background": "contentBackground",
-      "capsLockIconColor": "",
       "caretForeground": "foreground",
       "foreground": "foreground",
       "inactiveForeground": "disabledForeground",
@@ -601,11 +506,6 @@
         "background": "grey17",
         "foreground": "infoPanelForeground"
       },
-      "Tab": {
-        "hoverBackground": "",
-        "selectedBackground": "",
-        "selectedForeground": ""
-      },
       "background": "contentBackground",
       "borderColor": "border",
       "disabledForeground": "disabledForeground",
@@ -620,29 +520,13 @@
       "Advertiser": {
         "background": "panel",
         "borderColor": "border",
-        "borderInsets": "",
         "foreground": "infoPanelForeground"
-      },
-      "Body": {
-        "bottomInsetBeforeAd": "",
-        "bottomInsetNoAd": "",
-        "topInsetNoHeader": ""
       },
       "Header": {
         "activeBackground": "grey13",
         "activeForeground": "foreground",
         "inactiveBackground": "grey14",
-        "inactiveForeground": "disabledForeground",
-        "insets": ""
-      },
-      "SearchField": {
-        "borderInsets": "",
-        "inputInsets": ""
-      },
-      "Selection": {
-        "arc": "",
-        "innerInsets": "",
-        "leftRightInset": ""
+        "inactiveForeground": "disabledForeground"
       },
       "Toolbar": {
         "background": "grey17",
@@ -650,36 +534,17 @@
       },
       "background": "contentBackground",
       "borderColor": "grey05",
-      "borderWidth": "",
       "inactiveBorderColor": "grey05",
-      "innerBorderColor": "",
-      "paintBorder": "",
       "separatorColor": "lightBorder",
-      "separatorForeground": "separatorForeground",
-      "separatorInsets": "",
-      "separatorLabelInsets": ""
+      "separatorForeground": "separatorForeground"
     },
     "PopupMenu": {
-      "Selection": {
-        "arc": "",
-        "innerInsets": "",
-        "outerInsets": ""
-      },
       "background": "panel",
       "borderInsets": "6,1,6,1",
-      "borderWidth": "",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground",
       "translucentBackground": "panel"
-    },
-    "PopupMenuSeparator": {
-      "height": "",
-      "stripeIndent": "",
-      "stripeWidth": ""
-    },
-    "ProblemsView": {
-      "projectAnalysisButtonBackground": ""
     },
     "ProgressBar": {
       "background": "panel",
@@ -709,7 +574,6 @@
       "acceleratorForeground": "foreground",
       "acceleratorSelectionForeground": "selectionForeground",
       "background": "panel",
-      "disabledBackground": "",
       "disabledForeground": "disabledForeground",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
@@ -718,9 +582,6 @@
     "RunToolbar": {
       "Debug": {
         "activeBackground": "#f4e7d2"
-      },
-      "Profile": {
-        "activeBackground": ""
       },
       "Run": {
         "activeBackground": "#eaead3"
@@ -782,7 +643,6 @@
     "SearchEverywhere": {
       "Advertiser": {
         "background": "panel",
-        "borderInsets": "",
         "foreground": "infoPanelForeground"
       },
       "Header": {
@@ -830,9 +690,6 @@
         "borderColor": "#c2da8764"
       }
     },
-    "SettingsTree": {
-      "rowHeight": ""
-    },
     "SidePanel": {
       "background": "#ede9e0"
     },
@@ -877,8 +734,6 @@
       "focusColor": "#e1e3e0",
       "foreground": "foreground",
       "hoverColor": "grey11",
-      "tabSelectionArc": "",
-      "tabSelectionHeight": "",
       "underlineColor": "#6595c6"
     },
     "Table": {
@@ -898,8 +753,6 @@
       "lightSelectionInactiveForeground": "foreground",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground",
-      "selectionInactiveBackground": "",
-      "selectionInactiveForeground": "",
       "sortIconColor": "#c3cee0",
       "stripeColor": "#f7f0e5"
     },
@@ -923,9 +776,6 @@
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground"
     },
-    "TextComponent": {
-      "selectionBackgroundInactive": ""
-    },
     "TextField": {
       "background": "contentBackground",
       "caretForeground": "foreground",
@@ -940,7 +790,6 @@
       "background": "panel",
       "caretForeground": "foreground",
       "foreground": "foreground",
-      "inactiveBackground": "",
       "inactiveForeground": "disabledForeground",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground"
@@ -975,16 +824,13 @@
     },
     "ToolBar": {
       "background": "panel",
-      "borderHandleColor": "",
       "darkShadow": "#7f8e9b",
       "floatingForeground": "#c3cee0",
       "foreground": "foreground",
       "highlight": "white",
-      "horizontalToolbarInsets": "",
       "light": "white",
       "separatorColor": "border",
-      "shadow": "#c3cee0",
-      "verticalToolbarInsets": ""
+      "shadow": "#c3cee0"
     },
     "ToolTip": {
       "Actions": {
@@ -996,7 +842,6 @@
       "foreground": "foreground",
       "infoForeground": "infoPanelForeground",
       "linkForeground": "linkForeground",
-      "paintBorder": "",
       "shortcutForeground": "infoPanelForeground"
     },
     "ToolWindow": {
@@ -1008,8 +853,7 @@
       "Header": {
         "background": "#e7e4de",
         "borderColor": "border",
-        "inactiveBackground": "panel",
-        "padding": ""
+        "inactiveBackground": "panel"
       },
       "HeaderCloseButton": {
         "background": "grey07"
@@ -1018,19 +862,14 @@
         "hoverBackground": "#4e535919",
         "hoverInactiveBackground": "#4e535919",
         "inactiveUnderlineColor": "#a1aab7",
-        "padding": "",
         "selectedInactiveBackground": "grey11",
-        "underlineColor": "#6595c6",
-        "underlineHeight": "",
-        "underlinedTabBackground": "",
-        "underlinedTabInactiveBackground": ""
+        "underlineColor": "#6595c6"
       },
       "background": "contentBackground"
     },
     "Toolbar": {
       "Floating": {
-        "background": "grey14",
-        "borderColor": ""
+        "background": "grey14"
       }
     },
     "Tooltip": {
@@ -1046,9 +885,6 @@
       "separatorColor": "border"
     },
     "Tree": {
-      "Selection": {
-        "arc": ""
-      },
       "background": "contentBackground",
       "errorForeground": "#b14645",
       "forceFocusedSelectionForeground": false,
@@ -1057,19 +893,9 @@
       "hoverBackground": "#eeece6",
       "hoverInactiveBackground": "grey16",
       "modifiedItemForeground": "#296da3",
-      "paintLines": "",
-      "rowHeight": "",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground",
       "selectionInactiveBackground": "grey11"
-    },
-    "UiDesigner": {
-      "Panel": {
-        "background": ""
-      },
-      "Preview": {
-        "background": ""
-      }
     },
     "ValidationTooltip": {
       "errorBackground": "#fae3d5",
@@ -1107,7 +933,6 @@
           },
           "currentBranchBackground": "#f0ede8",
           "hoveredBackground": "#cbd4db66",
-          "rowHeight": "",
           "selectionBackground": "selectionBackground",
           "selectionForeground": "selectionForeground",
           "selectionInactiveBackground": "grey11",
@@ -1119,12 +944,10 @@
         "Toolbar": {
           "background": "panel"
         },
-        "borderColor": "#d1cbc1",
-        "borderInsets": ""
+        "borderColor": "#d1cbc1"
       },
       "RefLabel": {
         "backgroundBase": "black",
-        "backgroundBrightness": "",
         "foreground": "foreground"
       }
     },
@@ -1136,20 +959,12 @@
       "Details": {
         "background": "white"
       },
-      "LearnTab": {
-        "CourseCard": {
-          "hover": ""
-        }
-      },
       "Projects": {
         "actions": {
           "background": "#dfe5e8",
           "selectionBackground": "#618cd1",
           "selectionBorderColor": "#4f7bc5"
-        },
-        "background": "",
-        "selectionBackground": "",
-        "selectionInactiveBackground": ""
+        }
       },
       "SidePanel": {
         "background": "panel"
@@ -1164,9 +979,6 @@
       "headerBackground": "#e0d8cd",
       "headerForeground": "grey02",
       "separatorColor": "border"
-    },
-    "Window": {
-      "border": ""
     },
     "textText": "foreground",
     "window": "panel",

--- a/resources/PreciousLightWhite.theme.json
+++ b/resources/PreciousLightWhite.theme.json
@@ -104,9 +104,6 @@
       "ContrastBorderColor": "border",
       "color": "border"
     },
-    "Breakpoint": {
-      "iconHoverAlpha": ""
-    },
     "Button": {
       "Split": {
         "default": {
@@ -114,7 +111,6 @@
           "separatorColor": "#84abeb"
         }
       },
-      "arc": "",
       "background": "panel",
       "default": {
         "endBackground": "#6198d0",
@@ -133,7 +129,6 @@
       "focusedBorderColor": "#85acd8",
       "foreground": "foreground",
       "shadowColor": "#aaaaaa00",
-      "shadowWidth": "",
       "startBackground": "white",
       "startBorderColor": "componentBorder"
     },
@@ -147,7 +142,6 @@
       "acceleratorForeground": "foreground",
       "acceleratorSelectionForeground": "selectionForeground",
       "background": "panel",
-      "disabledBackground": "",
       "disabledForeground": "disabledForeground",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
@@ -176,43 +170,27 @@
     "ComboBoxButton": {
       "background": "contentBackground"
     },
-    "ComboPopup": {
-      "border": ""
-    },
     "CompletionPopup": {
       "Advertiser": {
         "background": "panel",
-        "borderInsets": "",
-        "fontSizeOffset": "",
         "foreground": "infoPanelForeground"
-      },
-      "Body": {
-        "insets": ""
       },
       "foreground": "foreground",
       "matchForeground": "linkForeground",
       "nonFocusedMask": "#55555500",
       "selectionBackground": "#d2e7fe",
-      "selectionInactiveBackground": "grey12",
-      "selectionInnerInsets": ""
+      "selectionInactiveBackground": "grey12"
     },
     "ComplexPopup": {
       "Header": {
-        "background": "contentBackground",
-        "insets": ""
-      },
-      "TextField": {
-        "borderInsets": "",
-        "inputInsets": ""
+        "background": "contentBackground"
       }
     },
     "Component": {
-      "arc": "",
       "borderColor": "componentBorder",
       "disabledBorderColor": "border",
       "errorFocusColor": "#e08a85",
       "focusColor": "#9cc5f1",
-      "focusWidth": "",
       "focusedBorderColor": "#85acd8",
       "hoverIconColor": "#859197e5",
       "iconColor": "#8591977f",
@@ -240,21 +218,12 @@
         "valueForeground": "#7a5350"
       }
     },
-    "DebuggerPopup": {
-      "borderColor": ""
-    },
-    "DebuggerTabs": {
-      "underlineHeight": "",
-      "underlinedTabBackground": ""
-    },
     "DefaultTabs": {
       "background": "panel",
       "borderColor": "border",
       "hoverBackground": "#55555519",
       "inactiveUnderlineColor": "#a3afc2",
       "underlineColor": "#6198d0",
-      "underlineHeight": "",
-      "underlinedTabBackground": "",
       "underlinedTabForeground": "foreground"
     },
     "DragAndDrop": {
@@ -265,8 +234,7 @@
     },
     "Editor": {
       "SearchField": {
-        "background": "contentBackground",
-        "borderInsets": ""
+        "background": "contentBackground"
       },
       "Toolbar": {
         "borderColor": "border"
@@ -279,7 +247,6 @@
       "background": "contentBackground",
       "caretForeground": "foreground",
       "foreground": "foreground",
-      "inactiveBackground": "",
       "inactiveForeground": "disabledForeground",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground",
@@ -291,14 +258,9 @@
       "hoverBackground": "#55555519",
       "inactiveColoredFileBackground": "#55555511",
       "inactiveUnderlineColor": "#a3afc2",
-      "tabInsets": "",
       "underlineColor": "#6198d0",
-      "underlineHeight": "",
       "underlinedTabBackground": "white",
-      "underlinedTabForeground": "foreground",
-      "unselectedAlpha": "",
-      "unselectedBlend": "",
-      "verticalTabInsets": ""
+      "underlinedTabForeground": "foreground"
     },
     "FileColor": {
       "Blue": "#e7f0fa",
@@ -329,24 +291,14 @@
       "Header": {
         "foreground": "foreground"
       },
-      "arc": "",
       "background": "grey17",
       "borderColor": "grey05",
-      "buttonBottomInset": "",
-      "buttonTopInset": "",
-      "codeBackground": "",
       "codeBorderColor": "grey08",
-      "codeForeground": "",
       "foreground": "foreground",
-      "iconInset": "",
-      "imageBottomInset": "",
-      "imageTopInset": "",
-      "insets": "",
       "linkForeground": "linkForeground",
       "shortcutBackground": "#e7eff8",
       "shortcutForeground": "foreground",
-      "stepForeground": "foreground",
-      "textInset": ""
+      "stepForeground": "foreground"
     },
     "Group": {
       "disabledSeparatorColor": "border",
@@ -356,14 +308,7 @@
       "infoForeground": "infoPanelForeground",
       "lineSeparatorColor": "grey12"
     },
-    "HelpTooltip": {
-      "borderColor": ""
-    },
     "IconBadge": {
-      "borderWidth": "",
-      "dotRadius": "",
-      "dotX": "",
-      "dotY": "",
       "errorBackground": "#da7570",
       "infoBackground": "#5099d6",
       "successBackground": "#73a159",
@@ -371,9 +316,6 @@
     },
     "InformationHint": {
       "borderColor": "#e5e5e5"
-    },
-    "InplaceRefactoringPopup": {
-      "borderColor": ""
     },
     "Label": {
       "background": "panel",
@@ -403,9 +345,7 @@
     "List": {
       "Button": {
         "hoverBackground": "#eef5fd",
-        "leftRightInset": "",
-        "separatorColor": "contentBackground",
-        "separatorInset": ""
+        "separatorColor": "contentBackground"
       },
       "Line": {
         "hoverBackground": "grey12"
@@ -428,11 +368,7 @@
       "transparentSelectionBackground": "selectionBackground"
     },
     "MainToolbar": {
-      "Dropdown": {
-        "maxWidth": ""
-      },
-      "background": "panel",
-      "separatorColor": ""
+      "background": "panel"
     },
     "MainWindow": {
       "FullScreeControl": {
@@ -455,17 +391,10 @@
       "usedBackground": "grey06"
     },
     "Menu": {
-      "Selection": {
-        "arc": "",
-        "innerInsets": "",
-        "outerInsets": ""
-      },
       "acceleratorForeground": "foreground",
       "acceleratorSelectionForeground": "selectionForeground",
       "background": "panel",
       "borderColor": "lightBorder",
-      "borderInsets": "",
-      "disabledBackground": "",
       "disabledForeground": "disabledForeground",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
@@ -475,17 +404,13 @@
     "MenuBar": {
       "borderColor": "lightBorder",
       "disabledBackground": "border",
-      "disabledForeground": "",
       "foreground": "foreground",
       "highlight": "white",
-      "selectionBackground": "",
-      "selectionForeground": "",
       "shadow": "#c3d5f1"
     },
     "MenuItem": {
       "acceleratorForeground": "infoPanelForeground",
       "background": "panel",
-      "disabledBackground": "",
       "disabledForeground": "disabledForeground",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
@@ -516,37 +441,18 @@
         "warningBorderColor": "#c0ad84",
         "warningForeground": "foreground"
       },
-      "arc": "",
       "background": "panel",
       "borderColor": "border",
-      "borderInsets": "",
-      "contentActionsInset": "",
       "errorBackground": "#fbedee",
       "errorBorderColor": "#e4b1ad",
       "errorForeground": "foreground",
-      "foreground": "foreground",
-      "iconOffsetSize": "",
-      "linkForeground": "",
-      "titleActionsInset": "",
-      "titleContentInset": ""
+      "foreground": "foreground"
     },
     "NotificationsToolwindow": {
-      "Notification": {
-        "hoverBackground": ""
-      },
       "newNotification": {
         "background": "#e7eff8",
         "hoverBackground": "#e7eff8"
       }
-    },
-    "OnePixelDivider": {
-      "background": ""
-    },
-    "OptionButton": {
-      "default": {
-        "separatorColor": ""
-      },
-      "separatorColor": ""
     },
     "OptionPane": {
       "background": "panel",
@@ -570,7 +476,6 @@
     },
     "PasswordField": {
       "background": "contentBackground",
-      "capsLockIconColor": "",
       "caretForeground": "foreground",
       "foreground": "foreground",
       "inactiveForeground": "disabledForeground",
@@ -601,11 +506,6 @@
         "background": "grey17",
         "foreground": "infoPanelForeground"
       },
-      "Tab": {
-        "hoverBackground": "",
-        "selectedBackground": "",
-        "selectedForeground": ""
-      },
       "background": "contentBackground",
       "borderColor": "border",
       "disabledForeground": "disabledForeground",
@@ -620,29 +520,13 @@
       "Advertiser": {
         "background": "panel",
         "borderColor": "border",
-        "borderInsets": "",
         "foreground": "infoPanelForeground"
-      },
-      "Body": {
-        "bottomInsetBeforeAd": "",
-        "bottomInsetNoAd": "",
-        "topInsetNoHeader": ""
       },
       "Header": {
         "activeBackground": "grey13",
         "activeForeground": "foreground",
         "inactiveBackground": "grey14",
-        "inactiveForeground": "disabledForeground",
-        "insets": ""
-      },
-      "SearchField": {
-        "borderInsets": "",
-        "inputInsets": ""
-      },
-      "Selection": {
-        "arc": "",
-        "innerInsets": "",
-        "leftRightInset": ""
+        "inactiveForeground": "disabledForeground"
       },
       "Toolbar": {
         "background": "grey17",
@@ -650,36 +534,17 @@
       },
       "background": "contentBackground",
       "borderColor": "grey05",
-      "borderWidth": "",
       "inactiveBorderColor": "grey05",
-      "innerBorderColor": "",
-      "paintBorder": "",
       "separatorColor": "lightBorder",
-      "separatorForeground": "separatorForeground",
-      "separatorInsets": "",
-      "separatorLabelInsets": ""
+      "separatorForeground": "separatorForeground"
     },
     "PopupMenu": {
-      "Selection": {
-        "arc": "",
-        "innerInsets": "",
-        "outerInsets": ""
-      },
       "background": "panel",
       "borderInsets": "6,1,6,1",
-      "borderWidth": "",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground",
       "translucentBackground": "panel"
-    },
-    "PopupMenuSeparator": {
-      "height": "",
-      "stripeIndent": "",
-      "stripeWidth": ""
-    },
-    "ProblemsView": {
-      "projectAnalysisButtonBackground": ""
     },
     "ProgressBar": {
       "background": "panel",
@@ -709,7 +574,6 @@
       "acceleratorForeground": "foreground",
       "acceleratorSelectionForeground": "selectionForeground",
       "background": "panel",
-      "disabledBackground": "",
       "disabledForeground": "disabledForeground",
       "foreground": "foreground",
       "selectionBackground": "selectionBackground",
@@ -718,9 +582,6 @@
     "RunToolbar": {
       "Debug": {
         "activeBackground": "#f5f0e7"
-      },
-      "Profile": {
-        "activeBackground": ""
       },
       "Run": {
         "activeBackground": "#ebf3e8"
@@ -782,7 +643,6 @@
     "SearchEverywhere": {
       "Advertiser": {
         "background": "panel",
-        "borderInsets": "",
         "foreground": "infoPanelForeground"
       },
       "Header": {
@@ -830,9 +690,6 @@
         "borderColor": "#c8e18f64"
       }
     },
-    "SettingsTree": {
-      "rowHeight": ""
-    },
     "SidePanel": {
       "background": "#edf2f7"
     },
@@ -877,8 +734,6 @@
       "focusColor": "#e1ecf5",
       "foreground": "foreground",
       "hoverColor": "grey11",
-      "tabSelectionArc": "",
-      "tabSelectionHeight": "",
       "underlineColor": "#6198d0"
     },
     "Table": {
@@ -898,8 +753,6 @@
       "lightSelectionInactiveForeground": "foreground",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground",
-      "selectionInactiveBackground": "",
-      "selectionInactiveForeground": "",
       "sortIconColor": "#c3d5f1",
       "stripeColor": "#f7fafe"
     },
@@ -923,9 +776,6 @@
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground"
     },
-    "TextComponent": {
-      "selectionBackgroundInactive": ""
-    },
     "TextField": {
       "background": "contentBackground",
       "caretForeground": "foreground",
@@ -940,7 +790,6 @@
       "background": "panel",
       "caretForeground": "foreground",
       "foreground": "foreground",
-      "inactiveBackground": "",
       "inactiveForeground": "disabledForeground",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground"
@@ -975,16 +824,13 @@
     },
     "ToolBar": {
       "background": "panel",
-      "borderHandleColor": "",
       "darkShadow": "#8192a2",
       "floatingForeground": "#c3d5f1",
       "foreground": "foreground",
       "highlight": "white",
-      "horizontalToolbarInsets": "",
       "light": "white",
       "separatorColor": "border",
-      "shadow": "#c3d5f1",
-      "verticalToolbarInsets": ""
+      "shadow": "#c3d5f1"
     },
     "ToolTip": {
       "Actions": {
@@ -996,7 +842,6 @@
       "foreground": "foreground",
       "infoForeground": "infoPanelForeground",
       "linkForeground": "linkForeground",
-      "paintBorder": "",
       "shortcutForeground": "infoPanelForeground"
     },
     "ToolWindow": {
@@ -1008,8 +853,7 @@
       "Header": {
         "background": "#e8edf4",
         "borderColor": "border",
-        "inactiveBackground": "panel",
-        "padding": ""
+        "inactiveBackground": "panel"
       },
       "HeaderCloseButton": {
         "background": "grey07"
@@ -1018,19 +862,14 @@
         "hoverBackground": "#55555519",
         "hoverInactiveBackground": "#55555519",
         "inactiveUnderlineColor": "#a3afc2",
-        "padding": "",
         "selectedInactiveBackground": "grey11",
-        "underlineColor": "#6198d0",
-        "underlineHeight": "",
-        "underlinedTabBackground": "",
-        "underlinedTabInactiveBackground": ""
+        "underlineColor": "#6198d0"
       },
       "background": "contentBackground"
     },
     "Toolbar": {
       "Floating": {
-        "background": "grey14",
-        "borderColor": ""
+        "background": "grey14"
       }
     },
     "Tooltip": {
@@ -1046,9 +885,6 @@
       "separatorColor": "border"
     },
     "Tree": {
-      "Selection": {
-        "arc": ""
-      },
       "background": "contentBackground",
       "errorForeground": "#ae4947",
       "forceFocusedSelectionForeground": false,
@@ -1057,19 +893,9 @@
       "hoverBackground": "#eef5fd",
       "hoverInactiveBackground": "grey16",
       "modifiedItemForeground": "#186daa",
-      "paintLines": "",
-      "rowHeight": "",
       "selectionBackground": "selectionBackground",
       "selectionForeground": "selectionForeground",
       "selectionInactiveBackground": "grey11"
-    },
-    "UiDesigner": {
-      "Panel": {
-        "background": ""
-      },
-      "Preview": {
-        "background": ""
-      }
     },
     "ValidationTooltip": {
       "errorBackground": "#fbecea",
@@ -1107,7 +933,6 @@
           },
           "currentBranchBackground": "#f0f6ff",
           "hoveredBackground": "#cbdbed66",
-          "rowHeight": "",
           "selectionBackground": "selectionBackground",
           "selectionForeground": "selectionForeground",
           "selectionInactiveBackground": "grey11",
@@ -1119,12 +944,10 @@
         "Toolbar": {
           "background": "panel"
         },
-        "borderColor": "#d3d3d3",
-        "borderInsets": ""
+        "borderColor": "#d3d3d3"
       },
       "RefLabel": {
         "backgroundBase": "black",
-        "backgroundBrightness": "",
         "foreground": "foreground"
       }
     },
@@ -1136,20 +959,12 @@
       "Details": {
         "background": "white"
       },
-      "LearnTab": {
-        "CourseCard": {
-          "hover": ""
-        }
-      },
       "Projects": {
         "actions": {
           "background": "#dfeefd",
           "selectionBackground": "#5d8ddb",
           "selectionBorderColor": "#4a7bce"
-        },
-        "background": "",
-        "selectionBackground": "",
-        "selectionInactiveBackground": ""
+        }
       },
       "SidePanel": {
         "background": "panel"
@@ -1164,9 +979,6 @@
       "headerBackground": "#e1e1e1",
       "headerForeground": "grey02",
       "separatorColor": "border"
-    },
-    "Window": {
-      "border": ""
     },
     "textText": "foreground",
     "window": "panel",


### PR DESCRIPTION
Apparently IJ 233.* doesn't like empty theme properties (that is, properties set to `""`) and throws exceptions when loading the plugin. This change attempts to fix this issue by removing all empty properties from the theme JSON files.