### PR TITLE
Improve running icons readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.gradle/
+/build/

--- a/resources/PreciousDarkEleven.theme.json
+++ b/resources/PreciousDarkEleven.theme.json
@@ -689,7 +689,7 @@
       "pressedBackground": "#b8b7b628",
       "runIconColor": "#568c42",
       "runningBackground": "#69872e",
-      "runningIconColor": "grey01",
+      "runningIconColor": "panel",
       "stopBackground": "#d86a65"
     },
     "ScrollBar": {

--- a/resources/PreciousDarkEleven.theme.json
+++ b/resources/PreciousDarkEleven.theme.json
@@ -117,7 +117,7 @@
         "endBorderColor": "#609fde",
         "focusColor": "#315378",
         "focusedBorderColor": "#385472",
-        "foreground": "white",
+        "foreground": "#d1d1d1",
         "shadowColor": "#61616200",
         "startBackground": "#4d80b3",
         "startBorderColor": "#609fde"

--- a/resources/PreciousDarkEleven.theme.json
+++ b/resources/PreciousDarkEleven.theme.json
@@ -689,7 +689,7 @@
       "pressedBackground": "#b8b7b628",
       "runIconColor": "#568c42",
       "runningBackground": "#69872e",
-      "runningIconColor": "panel",
+      "runningIconColor": "#dfe1e5",
       "stopBackground": "#d86a65"
     },
     "ScrollBar": {

--- a/resources/PreciousDarkFifteen.theme.json
+++ b/resources/PreciousDarkFifteen.theme.json
@@ -117,7 +117,7 @@
         "endBorderColor": "#60a0e0",
         "focusColor": "#35597f",
         "focusedBorderColor": "#3c5a79",
-        "foreground": "white",
+        "foreground": "#d1d1d1",
         "shadowColor": "#66676900",
         "startBackground": "#4f83b7",
         "startBorderColor": "#60a0e0"

--- a/resources/PreciousDarkFifteen.theme.json
+++ b/resources/PreciousDarkFifteen.theme.json
@@ -689,7 +689,7 @@
       "pressedBackground": "#bab9b628",
       "runIconColor": "#598f46",
       "runningBackground": "#6c8a33",
-      "runningIconColor": "panel",
+      "runningIconColor": "#dfe1e5",
       "stopBackground": "#da6c67"
     },
     "ScrollBar": {

--- a/resources/PreciousDarkFifteen.theme.json
+++ b/resources/PreciousDarkFifteen.theme.json
@@ -689,7 +689,7 @@
       "pressedBackground": "#bab9b628",
       "runIconColor": "#598f46",
       "runningBackground": "#6c8a33",
-      "runningIconColor": "grey01",
+      "runningIconColor": "panel",
       "stopBackground": "#da6c67"
     },
     "ScrollBar": {

--- a/resources/PreciousLightWarm.theme.json
+++ b/resources/PreciousLightWarm.theme.json
@@ -689,7 +689,7 @@
       "pressedBackground": "#4e535928",
       "runIconColor": "#6aa058",
       "runningBackground": "#7d9d43",
-      "runningIconColor": "grey01",
+      "runningIconColor": "panel",
       "stopBackground": "#cb645f"
     },
     "ScrollBar": {

--- a/resources/PreciousLightWhite.theme.json
+++ b/resources/PreciousLightWhite.theme.json
@@ -689,7 +689,7 @@
       "pressedBackground": "#55555528",
       "runIconColor": "#6da25b",
       "runningBackground": "#7f9f46",
-      "runningIconColor": "grey01",
+      "runningIconColor": "panel",
       "stopBackground": "#cb6762"
     },
     "ScrollBar": {


### PR DESCRIPTION
The goal is to use the panel color to improve running icons contrast and to improve readability

All of this changes are totally optional and can be drop as you wish 😃 

## Running icons

The third commit requires to be dropped or fixup to the second one.  
It is just a proposal of an alternative color for dark theme that looks better IMO.

### Before

<img width="114" alt="SCR-20241031-ossk" src="https://github.com/user-attachments/assets/8d12c469-dfd9-489a-82e8-633b25889b50">

<img width="114" alt="SCR-20241031-ossk" src="https://github.com/user-attachments/assets/f77bd25f-d93e-43f6-a908-c40f7ce73282">

### After

<img width="114" alt="SCR-20241031-ptur" src="https://github.com/user-attachments/assets/5849d30f-2fb9-40ef-9614-fd6f7ec9482b">

<img width="114" alt="SCR-20241031-ptta" src="https://github.com/user-attachments/assets/d6930774-239c-4563-b311-e4af0e57e1fa">

### Alternative dark color (better IMO)

<img width="114" alt="SCR-20241031-qhkw" src="https://github.com/user-attachments/assets/93344234-7c48-4f82-a831-cabaeaeb7278">

<img width="114" alt="SCR-20241031-qhkw" src="https://github.com/user-attachments/assets/41add0ef-3081-4df4-b41d-56b2df637c69">

## Default button

I also improve a little bit the contrast of the default pop button.

If you don't like it, just drop the commit 😉 

### Before


<img width="400" alt="SCR-20241031-qhkw" src="https://github.com/user-attachments/assets/5bbb41bb-4d4c-410a-a06b-73de64c3c634">

### After

<img width="400" alt="SCR-20241031-qhkw" src="https://github.com/user-attachments/assets/382f816b-ddc7-4291-a15d-35a3d41ff30c">

